### PR TITLE
Switch the library namespace to `WordHat`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         curl -I http://localhost:8000
         composer run ci-tests
       env:
-        BEHAT_PARAMS: "{\"extensions\":{\"PaulGibbs\\\\WordpressBehatExtension\":{\"default_driver\":\"${{ matrix.driver }}\"}}}"
+        BEHAT_PARAMS: "{\"extensions\":{\"WordHat\\\\Extension\":{\"default_driver\":\"${{ matrix.driver }}\"}}}"
 
     - name: Tests failed
       if: failure()

--- a/behat.yml
+++ b/behat.yml
@@ -2,16 +2,16 @@ default:
   suites:
     default:
       contexts:
-        - PaulGibbs\WordpressBehatExtension\Context\WordpressContext
+        - WordHat\Extension\Context\WordpressContext
         - Behat\MinkExtension\Context\MinkContext
-        - PaulGibbs\WordpressBehatExtension\Context\ContentContext
-        - PaulGibbs\WordpressBehatExtension\Context\DashboardContext
-        - PaulGibbs\WordpressBehatExtension\Context\SiteContext
-        - PaulGibbs\WordpressBehatExtension\Context\UserContext
-        - PaulGibbs\WordpressBehatExtension\Context\EditPostContext
-        - PaulGibbs\WordpressBehatExtension\Context\WidgetContext
-        - PaulGibbs\WordpressBehatExtension\Context\ToolbarContext
-        - PaulGibbs\WordpressBehatExtension\Context\DebugContext
+        - WordHat\Extension\Context\ContentContext
+        - WordHat\Extension\Context\DashboardContext
+        - WordHat\Extension\Context\SiteContext
+        - WordHat\Extension\Context\UserContext
+        - WordHat\Extension\Context\EditPostContext
+        - WordHat\Extension\Context\WidgetContext
+        - WordHat\Extension\Context\ToolbarContext
+        - WordHat\Extension\Context\DebugContext
         - FailAid\Context\FailureContext
 
   extensions:
@@ -32,7 +32,7 @@ default:
             api_url: http://localhost:9222
             validate_certificate: false
 
-    PaulGibbs\WordpressBehatExtension:
+    WordHat\Extension:
       default_driver: wpcli
       users:
         -

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,16 +2,16 @@ default:
   suites:
     default:
       contexts:
-        - PaulGibbs\WordpressBehatExtension\Context\WordpressContext
+        - WordHat\Extension\Context\WordpressContext
         - FeatureContext
         - Behat\MinkExtension\Context\MinkContext
-        - PaulGibbs\WordpressBehatExtension\Context\ContentContext
-        - PaulGibbs\WordpressBehatExtension\Context\DashboardContext
-        - PaulGibbs\WordpressBehatExtension\Context\SiteContext
-        - PaulGibbs\WordpressBehatExtension\Context\UserContext
-        - PaulGibbs\WordpressBehatExtension\Context\EditPostContext
-        - PaulGibbs\WordpressBehatExtension\Context\WidgetContext
-        - PaulGibbs\WordpressBehatExtension\Context\ToolbarContext
+        - WordHat\Extension\Context\ContentContext
+        - WordHat\Extension\Context\DashboardContext
+        - WordHat\Extension\Context\SiteContext
+        - WordHat\Extension\Context\UserContext
+        - WordHat\Extension\Context\EditPostContext
+        - WordHat\Extension\Context\WidgetContext
+        - WordHat\Extension\Context\ToolbarContext
 
   extensions:
     DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
@@ -31,7 +31,7 @@ default:
             api_url: http://localhost:9222
             validate_certificate: false
 
-    PaulGibbs\WordpressBehatExtension:
+    WordHat\Extension:
       default_driver: wpcli
       path: /path/to/wordpress
       users:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "autoload": {
     "psr-4": {
-      "PaulGibbs\\WordpressBehatExtension\\": "src"
+      "WordHat\\Extension\\": "src"
     },
     "files": [
       "src/Util/functions.php"

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -11,7 +11,7 @@ Consult the [Behat website](http://behat.org/en/latest/user_guide/configuration.
 These are the options provided by the WordHat extension:
 
 ```YAML
-PaulGibbs\WordpressBehatExtension:
+WordHat\Extension:
   default_driver: wpcli
   path: ~
 

--- a/src/Compiler/DriverElementPass.php
+++ b/src/Compiler/DriverElementPass.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Compiler;
+namespace WordHat\Extension\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
- * WordpressBehatExtension container compilation pass.
+ * Extension container compilation pass.
  */
 class DriverElementPass implements CompilerPassInterface
 {

--- a/src/Compiler/DriverPass.php
+++ b/src/Compiler/DriverPass.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Compiler;
+namespace WordHat\Extension\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
- * WordpressBehatExtension container compilation pass.
+ * Extension container compilation pass.
  */
 class DriverPass implements CompilerPassInterface
 {

--- a/src/Compiler/EventSubscriberPass.php
+++ b/src/Compiler/EventSubscriberPass.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Compiler;
+namespace WordHat\Extension\Compiler;
 
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Context/ContentContext.php
+++ b/src/Context/ContentContext.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use UnexpectedValueException;
 use RuntimeException;
 use Behat\Gherkin\Node\TableNode;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\ContentAwareContextTrait;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\UserAwareContextTrait;
+use WordHat\Extension\Context\Traits\ContentAwareContextTrait;
+use WordHat\Extension\Context\Traits\UserAwareContextTrait;
 
 /**
  * Provides step definitions for creating content: post types, comments, and terms.

--- a/src/Context/ContextClass/ClassGenerator.php
+++ b/src/Context/ContextClass/ClassGenerator.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\ContextClass;
+namespace WordHat\Extension\Context\ContextClass;
 
 use Behat\Behat\Context\ContextClass\ClassGenerator as BehatContextGenerator;
 use Behat\Testwork\Suite\Suite;
@@ -15,7 +15,7 @@ class ClassGenerator implements BehatContextGenerator
      */
     protected static $template = <<<'PHP'
 <?php
-{namespace}use PaulGibbs\WordpressBehatExtension\Context\RawWordpressContext;
+{namespace}use WordHat\Extension\Context\RawWordpressContext;
 
 use Behat\Behat\Tester\Exception\PendingException;
 

--- a/src/Context/DashboardContext.php
+++ b/src/Context/DashboardContext.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
-use PaulGibbs\WordpressBehatExtension\PageObject\DashboardPage;
+use WordHat\Extension\PageObject\DashboardPage;
 
 /**
  * Provides step definitions that are specific to the WordPress dashboard (wp-admin).

--- a/src/Context/DebugContext.php
+++ b/src/Context/DebugContext.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 /**
  * Provides step definitions for debugging step definitions.

--- a/src/Context/EditPostContext.php
+++ b/src/Context/EditPostContext.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
-use PaulGibbs\WordpressBehatExtension\PageObject\PostsEditPage;
+use WordHat\Extension\PageObject\PostsEditPage;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Exception\ExpectationException;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\ContentAwareContextTrait;
+use WordHat\Extension\Context\Traits\ContentAwareContextTrait;
 
 /**
  * Provides step definitions relating to editing content in wp-admin.

--- a/src/Context/Initialiser/WordpressAwareInitialiser.php
+++ b/src/Context/Initialiser/WordpressAwareInitialiser.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Initialiser;
+namespace WordHat\Extension\Context\Initialiser;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 
-use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
-use PaulGibbs\WordpressBehatExtension\Context\WordpressAwareInterface;
+use WordHat\Extension\WordpressDriverManager;
+use WordHat\Extension\Context\WordpressAwareInterface;
 
 /**
  * Behat Context initialiser.

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Behat\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
-use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\PageObjectAwareContextTrait;
-use PaulGibbs\WordpressBehatExtension\Driver\DriverInterface;
+use WordHat\Extension\WordpressDriverManager;
+use WordHat\Extension\Context\Traits\PageObjectAwareContextTrait;
+use WordHat\Extension\Driver\DriverInterface;
 use SensioLabs\Behat\PageObjectExtension\Context\PageObjectAware;
 
 /**
@@ -124,7 +124,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      *
      * @param string $name Optional. Name of specific driver to retrieve.
      *
-     * @return \PaulGibbs\WordpressBehatExtension\Driver\DriverInterface
+     * @return \WordHat\Extension\Driver\DriverInterface
      */
     public function getDriver(string $name = ''): DriverInterface
     {

--- a/src/Context/SiteContext.php
+++ b/src/Context/SiteContext.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 /**
  * Provides step definitions for managing plugins and themes.

--- a/src/Context/ToolbarContext.php
+++ b/src/Context/ToolbarContext.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Mink\Exception\ElementTextException;
 

--- a/src/Context/Traits/BaseAwarenessTrait.php
+++ b/src/Context/Traits/BaseAwarenessTrait.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
-use PaulGibbs\WordpressBehatExtension\Driver\DriverInterface;
+use WordHat\Extension\Driver\DriverInterface;
 
 /**
  * Parent class for all awareness traits providing common code.

--- a/src/Context/Traits/CacheAwareContextTrait.php
+++ b/src/Context/Traits/CacheAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to caching.

--- a/src/Context/Traits/CommentAwareContextTrait.php
+++ b/src/Context/Traits/CommentAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to comments.

--- a/src/Context/Traits/ContentAwareContextTrait.php
+++ b/src/Context/Traits/ContentAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to posts and content.

--- a/src/Context/Traits/DatabaseAwareContextTrait.php
+++ b/src/Context/Traits/DatabaseAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to the database.

--- a/src/Context/Traits/PageObjectAwareContextTrait.php
+++ b/src/Context/Traits/PageObjectAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 use RuntimeException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Factory as PageObjectFactory;

--- a/src/Context/Traits/PluginAwareContextTrait.php
+++ b/src/Context/Traits/PluginAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to plugins.

--- a/src/Context/Traits/TermAwareContextTrait.php
+++ b/src/Context/Traits/TermAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to terms.

--- a/src/Context/Traits/ThemeAwareContextTrait.php
+++ b/src/Context/Traits/ThemeAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to themes.

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
-use PaulGibbs\WordpressBehatExtension\PageObject\LoginPage;
+use WordHat\Extension\PageObject\LoginPage;
 use UnexpectedValueException;
 
 /**

--- a/src/Context/Traits/WidgetAwareContextTrait.php
+++ b/src/Context/Traits/WidgetAwareContextTrait.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+namespace WordHat\Extension\Context\Traits;
 
 trait WidgetAwareContextTrait
 {

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;

--- a/src/Context/WidgetContext.php
+++ b/src/Context/WidgetContext.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Gherkin\Node\TableNode;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\WidgetAwareContextTrait;
+use WordHat\Extension\Context\Traits\WidgetAwareContextTrait;
 
 /**
  * Provides step definitions relating to widgets.

--- a/src/Context/WordpressAwareInterface.php
+++ b/src/Context/WordpressAwareInterface.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Behat\Context\Context;
-use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
+use WordHat\Extension\WordpressDriverManager;
 
 /**
  * Common interface for Behat contexts.

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Context;
+namespace WordHat\Extension\Context;
 
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Driver\Selenium2Driver;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\CacheAwareContextTrait;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\DatabaseAwareContextTrait;
-use PaulGibbs\WordpressBehatExtension\Context\Traits\PageObjectAwareContextTrait;
+use WordHat\Extension\Context\Traits\CacheAwareContextTrait;
+use WordHat\Extension\Context\Traits\DatabaseAwareContextTrait;
+use WordHat\Extension\Context\Traits\PageObjectAwareContextTrait;
 
 /**
  * Provides step definitions for a range of common tasks. Recommended for all test suites.

--- a/src/Driver/BaseDriver.php
+++ b/src/Driver/BaseDriver.php
@@ -1,23 +1,23 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver;
+namespace WordHat\Extension\Driver;
 
-use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\ElementInterface;
+use WordHat\Extension\Exception\UnsupportedDriverActionException;
+use WordHat\Extension\Driver\Element\ElementInterface;
 
 /**
  * Common base class for WordPress drivers.
  *
  * A driver represents and manages the connection between the Behat environment and a WordPress site.
  *
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $cache
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $comment
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $content
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $database
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $plugin
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $term
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $theme
- * @property \PaulGibbs\WordpressBehatExtension\Driver\ElementInterface $user
+ * @property ElementInterface $cache
+ * @property ElementInterface $comment
+ * @property ElementInterface $content
+ * @property ElementInterface $database
+ * @property ElementInterface $plugin
+ * @property ElementInterface $term
+ * @property ElementInterface $theme
+ * @property ElementInterface $user
  */
 abstract class BaseDriver implements DriverInterface
 {
@@ -31,7 +31,7 @@ abstract class BaseDriver implements DriverInterface
     /**
      * Registered driver elements.
      *
-     * @var \PaulGibbs\WordpressBehatExtension\Driver\Element\ElementInterface[]
+     * @var Element\ElementInterface[]
      */
     protected $elements = [];
 
@@ -42,7 +42,7 @@ abstract class BaseDriver implements DriverInterface
      *
      * @throws UnsupportedDriverActionException
      *
-     * @return null|\PaulGibbs\WordpressBehatExtension\Driver\Element\ElementInterface Return element object.
+     * @return null|Element\ElementInterface Return element object.
      */
     public function __get(string $name)
     {

--- a/src/Driver/BlackboxDriver.php
+++ b/src/Driver/BlackboxDriver.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver;
+namespace WordHat\Extension\Driver;
 
 /**
  * Connect Behat to WordPress using just a web browser.

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver;
+namespace WordHat\Extension\Driver;
 
 /**
  * WordPress driver interface.

--- a/src/Driver/Element/BaseElement.php
+++ b/src/Driver/Element/BaseElement.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element;
+namespace WordHat\Extension\Driver\Element;
 
-use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;
-use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
+use WordHat\Extension\Exception\UnsupportedDriverActionException;
+use WordHat\Extension\WordpressDriverManager;
 
 /**
  * Common base class for WordPress driver elements.

--- a/src/Driver/Element/ElementInterface.php
+++ b/src/Driver/Element/ElementInterface.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element;
+namespace WordHat\Extension\Driver\Element;
 
 /**
  * WordPress driver element interface.

--- a/src/Driver/Element/Wpcli/CacheElement.php
+++ b/src/Driver/Element/Wpcli/CacheElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-CLI driver element for site cache.

--- a/src/Driver/Element/Wpcli/CommentElement.php
+++ b/src/Driver/Element/Wpcli/CommentElement.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
-use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
+use function WordHat\Extension\Util\buildCLIArgs;
 
 /**
  * WP-CLI driver element for post comments.

--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
-use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
+use function WordHat\Extension\Util\buildCLIArgs;
 
 /**
  * WP-CLI driver element for content (i.e. blog posts).

--- a/src/Driver/Element/Wpcli/DatabaseElement.php
+++ b/src/Driver/Element/Wpcli/DatabaseElement.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
 use RuntimeException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-CLI driver element for manipulating the database directly.

--- a/src/Driver/Element/Wpcli/PluginElement.php
+++ b/src/Driver/Element/Wpcli/PluginElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-CLI driver element for plugins.

--- a/src/Driver/Element/Wpcli/TermElement.php
+++ b/src/Driver/Element/Wpcli/TermElement.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
 use UnexpectedValueException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
-use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
+use WordHat\Extension\Driver\Element\BaseElement;
+use function WordHat\Extension\Util\buildCLIArgs;
 
 /**
  * WP-CLI driver element for taxonomy terms.

--- a/src/Driver/Element/Wpcli/ThemeElement.php
+++ b/src/Driver/Element/Wpcli/ThemeElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-CLI driver element for themes.

--- a/src/Driver/Element/Wpcli/UserElement.php
+++ b/src/Driver/Element/Wpcli/UserElement.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
-use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
+use WordHat\Extension\Driver\Element\BaseElement;
+use function WordHat\Extension\Util\buildCLIArgs;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+namespace WordHat\Extension\Driver\Element\Wpcli;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
-use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
+use function WordHat\Extension\Util\buildCLIArgs;
 
 /**
  * WP-API driver element for managing user accounts.

--- a/src/Driver/Element/Wpphp/CacheElement.php
+++ b/src/Driver/Element/Wpphp/CacheElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-API driver element for site cache.

--- a/src/Driver/Element/Wpphp/CommentElement.php
+++ b/src/Driver/Element/Wpphp/CommentElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/Element/Wpphp/ContentElement.php
+++ b/src/Driver/Element/Wpphp/ContentElement.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
 use WP_Query;
 use UnexpectedValueException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-API driver element for content (i.e. blog posts).

--- a/src/Driver/Element/Wpphp/DatabaseElement.php
+++ b/src/Driver/Element/Wpphp/DatabaseElement.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
 use RuntimeException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-API driver element for manipulating the database directly.

--- a/src/Driver/Element/Wpphp/PluginElement.php
+++ b/src/Driver/Element/Wpphp/PluginElement.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
 use UnexpectedValueException;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 
 /**
  * WP-API driver element for plugins.

--- a/src/Driver/Element/Wpphp/TermElement.php
+++ b/src/Driver/Element/Wpphp/TermElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/Element/Wpphp/ThemeElement.php
+++ b/src/Driver/Element/Wpphp/ThemeElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/Element/Wpphp/UserElement.php
+++ b/src/Driver/Element/Wpphp/UserElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/Element/Wpphp/WidgetElement.php
+++ b/src/Driver/Element/Wpphp/WidgetElement.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+namespace WordHat\Extension\Driver\Element\Wpphp;
 
-use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use WordHat\Extension\Driver\Element\BaseElement;
 use UnexpectedValueException;
 
 /**

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver;
+namespace WordHat\Extension\Driver;
 
 use RuntimeException;
 use UnexpectedValueException;

--- a/src/Driver/WpphpDriver.php
+++ b/src/Driver/WpphpDriver.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Driver;
+namespace WordHat\Extension\Driver;
 
 use RuntimeException;
 

--- a/src/Exception/UnsupportedDriverActionException.php
+++ b/src/Exception/UnsupportedDriverActionException.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Exception;
+namespace WordHat\Extension\Exception;
 
 use Exception;
 

--- a/src/Listener/DriverListener.php
+++ b/src/Listener/DriverListener.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Listener;
+namespace WordHat\Extension\Listener;
 
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
-use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
+use WordHat\Extension\WordpressDriverManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/PageObject/AdminPage.php
+++ b/src/PageObject/AdminPage.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject;
+namespace WordHat\Extension\PageObject;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;

--- a/src/PageObject/DashboardPage.php
+++ b/src/PageObject/DashboardPage.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject;
+namespace WordHat\Extension\PageObject;
 
 use Behat\Mink\Exception\ExpectationException;
 

--- a/src/PageObject/Element/AdminMenu.php
+++ b/src/PageObject/Element/AdminMenu.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
+namespace WordHat\Extension\PageObject\Element;
 
 use RuntimeException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
-use PaulGibbs\WordpressBehatExtension\Util;
+use WordHat\Extension\Util;
 
 /**
  * An Element representing the admin menu.

--- a/src/PageObject/Element/PostContentEditor.php
+++ b/src/PageObject/Element/PostContentEditor.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
+namespace WordHat\Extension\PageObject\Element;
 
 /**
  * An Element representing the TinyMCE editor on the edit post screen.

--- a/src/PageObject/Element/TinyMCEEditor.php
+++ b/src/PageObject/Element/TinyMCEEditor.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
+namespace WordHat\Extension\PageObject\Element;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
+namespace WordHat\Extension\PageObject\Element;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Exception\ExpectationException;
-use PaulGibbs\WordpressBehatExtension\Util;
+use WordHat\Extension\Util;
 
 /**
  * An Element representing the admin menu.

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace PaulGibbs\WordpressBehatExtension\PageObject;
+namespace WordHat\Extension\PageObject;
 
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
-use PaulGibbs\WordpressBehatExtension\Context\RawWordpressContext;
+use WordHat\Extension\Context\RawWordpressContext;
 
 /**
  * Page object representing the WordPress log-in page.

--- a/src/PageObject/PostsEditPage.php
+++ b/src/PageObject/PostsEditPage.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\PageObject;
+namespace WordHat\Extension\PageObject;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;

--- a/src/ServiceContainer/Extension.php
+++ b/src/ServiceContainer/Extension.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\ServiceContainer;
+namespace WordHat\Extension\ServiceContainer;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
@@ -14,16 +14,16 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-use PaulGibbs\WordpressBehatExtension\Compiler\DriverPass;
-use PaulGibbs\WordpressBehatExtension\Compiler\DriverElementPass;
-use PaulGibbs\WordpressBehatExtension\Compiler\EventSubscriberPass;
+use WordHat\Extension\Compiler\DriverPass;
+use WordHat\Extension\Compiler\DriverElementPass;
+use WordHat\Extension\Compiler\EventSubscriberPass;
 
 use RuntimeException;
 
 /**
  * Main part of the Behat extension.
  */
-class WordpressBehatExtension implements ExtensionInterface
+class Extension implements ExtensionInterface
 {
     /**
      * @var ServiceProcessor
@@ -296,7 +296,7 @@ class WordpressBehatExtension implements ExtensionInterface
      */
     protected function processClassGenerator(ContainerBuilder $container)
     {
-        $definition = new Definition('PaulGibbs\WordpressBehatExtension\Context\ContextClass\ClassGenerator');
+        $definition = new Definition('WordHat\Extension\Context\ContextClass\ClassGenerator');
         $container->setDefinition(ContextExtension::CLASS_GENERATOR_TAG . '.simple', $definition);
     }
 
@@ -309,10 +309,10 @@ class WordpressBehatExtension implements ExtensionInterface
     {
         // Append our namespaces as earlier namespaces take precedence.
         $pages = $container->getParameter('sensio_labs.page_object_extension.namespaces.page');
-        $pages[] = 'PaulGibbs\WordpressBehatExtension\PageObject';
+        $pages[] = 'WordHat\Extension\PageObject';
 
         $elements = $container->getParameter('sensio_labs.page_object_extension.namespaces.element');
-        $elements[] = 'PaulGibbs\WordpressBehatExtension\PageObject\Element';
+        $elements[] = 'WordHat\Extension\PageObject\Element';
 
         $container->setParameter('sensio_labs.page_object_extension.namespaces.page', $pages);
         $container->setParameter('sensio_labs.page_object_extension.namespaces.element', $elements);

--- a/src/ServiceContainer/config/drivers/blackbox.yml
+++ b/src/ServiceContainer/config/drivers/blackbox.yml
@@ -1,5 +1,5 @@
 parameters:
-  wordpress.driver.blackbox.class: PaulGibbs\WordpressBehatExtension\Driver\BlackboxDriver
+  wordpress.driver.blackbox.class: WordHat\Extension\Driver\BlackboxDriver
 
 services:
   wordpress.driver.blackbox:

--- a/src/ServiceContainer/config/drivers/wpcli.yml
+++ b/src/ServiceContainer/config/drivers/wpcli.yml
@@ -1,14 +1,14 @@
 parameters:
-  wordpress.driver.wpcli.class: PaulGibbs\WordpressBehatExtension\Driver\WpcliDriver
-  wordpress.element.wpcli.cache.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\CacheElement
-  wordpress.element.wpcli.comment.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\CommentElement
-  wordpress.element.wpcli.content.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ContentElement
-  wordpress.element.wpcli.database.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\DatabaseElement
-  wordpress.element.wpcli.plugin.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\PluginElement
-  wordpress.element.wpcli.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\TermElement
-  wordpress.element.wpcli.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ThemeElement
-  wordpress.element.wpcli.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\UserElement
-  wordpress.element.wpcli.widget.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\WidgetElement
+  wordpress.driver.wpcli.class: WordHat\Extension\Driver\WpcliDriver
+  wordpress.element.wpcli.cache.class: WordHat\Extension\Driver\Element\Wpcli\CacheElement
+  wordpress.element.wpcli.comment.class: WordHat\Extension\Driver\Element\Wpcli\CommentElement
+  wordpress.element.wpcli.content.class: WordHat\Extension\Driver\Element\Wpcli\ContentElement
+  wordpress.element.wpcli.database.class: WordHat\Extension\Driver\Element\Wpcli\DatabaseElement
+  wordpress.element.wpcli.plugin.class: WordHat\Extension\Driver\Element\Wpcli\PluginElement
+  wordpress.element.wpcli.term.class: WordHat\Extension\Driver\Element\Wpcli\TermElement
+  wordpress.element.wpcli.theme.class: WordHat\Extension\Driver\Element\Wpcli\ThemeElement
+  wordpress.element.wpcli.user.class: WordHat\Extension\Driver\Element\Wpcli\UserElement
+  wordpress.element.wpcli.widget.class: WordHat\Extension\Driver\Element\Wpcli\WidgetElement
 
 services:
   wordpress.driver.wpcli:

--- a/src/ServiceContainer/config/drivers/wpphp.yml
+++ b/src/ServiceContainer/config/drivers/wpphp.yml
@@ -1,14 +1,14 @@
 parameters:
-  wordpress.driver.wpphp.class: PaulGibbs\WordpressBehatExtension\Driver\WpphpDriver
-  wordpress.element.wpphp.cache.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\CacheElement
-  wordpress.element.wpphp.comment.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\CommentElement
-  wordpress.element.wpphp.content.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\ContentElement
-  wordpress.element.wpphp.database.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\DatabaseElement
-  wordpress.element.wpphp.plugin.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\PluginElement
-  wordpress.element.wpphp.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\TermElement
-  wordpress.element.wpphp.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\ThemeElement
-  wordpress.element.wpphp.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\UserElement
-  wordpress.element.wpphp.widget.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\WidgetElement
+  wordpress.driver.wpphp.class: WordHat\Extension\Driver\WpphpDriver
+  wordpress.element.wpphp.cache.class: WordHat\Extension\Driver\Element\Wpphp\CacheElement
+  wordpress.element.wpphp.comment.class: WordHat\Extension\Driver\Element\Wpphp\CommentElement
+  wordpress.element.wpphp.content.class: WordHat\Extension\Driver\Element\Wpphp\ContentElement
+  wordpress.element.wpphp.database.class: WordHat\Extension\Driver\Element\Wpphp\DatabaseElement
+  wordpress.element.wpphp.plugin.class: WordHat\Extension\Driver\Element\Wpphp\PluginElement
+  wordpress.element.wpphp.term.class: WordHat\Extension\Driver\Element\Wpphp\TermElement
+  wordpress.element.wpphp.theme.class: WordHat\Extension\Driver\Element\Wpphp\ThemeElement
+  wordpress.element.wpphp.user.class: WordHat\Extension\Driver\Element\Wpphp\UserElement
+  wordpress.element.wpphp.widget.class: WordHat\Extension\Driver\Element\Wpphp\WidgetElement
 
 services:
   wordpress.driver.wpphp:

--- a/src/ServiceContainer/config/services.yml
+++ b/src/ServiceContainer/config/services.yml
@@ -4,18 +4,18 @@ parameters:
 
 services:
   wordpress.wordpress:
-    class: 'PaulGibbs\WordpressBehatExtension\WordpressDriverManager'
+    class: 'WordHat\Extension\WordpressDriverManager'
     arguments:
       - {}
   wordpress.context.initializer:
-    class: 'PaulGibbs\WordpressBehatExtension\Context\Initialiser\WordpressAwareInitialiser'
+    class: 'WordHat\Extension\Context\Initialiser\WordpressAwareInitialiser'
     arguments:
       - "@wordpress.wordpress"
       - "%wordpress.parameters%"
     tags:
       - { name: context.initializer }
   wordpress.listener.driver:
-    class: 'PaulGibbs\WordpressBehatExtension\Listener\DriverListener'
+    class: 'WordHat\Extension\Listener\DriverListener'
     arguments:
       - "@wordpress.wordpress"
       - "%wordpress.parameters%"

--- a/src/Util/functions.php
+++ b/src/Util/functions.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension\Util;
+namespace WordHat\Extension\Util;
 
 use Exception;
 use DOMDocument;

--- a/src/WordpressDriverManager.php
+++ b/src/WordpressDriverManager.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace PaulGibbs\WordpressBehatExtension;
+namespace WordHat\Extension;
 
-use PaulGibbs\WordpressBehatExtension\Driver\DriverInterface;
-use PaulGibbs\WordpressBehatExtension\Driver\Element\ElementInterface;
+use WordHat\Extension\Driver\DriverInterface;
+use WordHat\Extension\Driver\Element\ElementInterface;
 
 use InvalidArgumentException;
 

--- a/tests/app/behat-ci.yml
+++ b/tests/app/behat-ci.yml
@@ -4,16 +4,16 @@ default:
       paths:
         - '%paths.base%/../../features'
       contexts:
-        - PaulGibbs\WordpressBehatExtension\Context\WordpressContext
+        - WordHat\Extension\Context\WordpressContext
         - Behat\MinkExtension\Context\MinkContext
-        - PaulGibbs\WordpressBehatExtension\Context\ContentContext
-        - PaulGibbs\WordpressBehatExtension\Context\DashboardContext
-        - PaulGibbs\WordpressBehatExtension\Context\SiteContext
-        - PaulGibbs\WordpressBehatExtension\Context\UserContext
-        - PaulGibbs\WordpressBehatExtension\Context\EditPostContext
-        - PaulGibbs\WordpressBehatExtension\Context\WidgetContext
-        - PaulGibbs\WordpressBehatExtension\Context\ToolbarContext
-        - PaulGibbs\WordpressBehatExtension\Context\DebugContext
+        - WordHat\Extension\Context\ContentContext
+        - WordHat\Extension\Context\DashboardContext
+        - WordHat\Extension\Context\SiteContext
+        - WordHat\Extension\Context\UserContext
+        - WordHat\Extension\Context\EditPostContext
+        - WordHat\Extension\Context\WidgetContext
+        - WordHat\Extension\Context\ToolbarContext
+        - WordHat\Extension\Context\DebugContext
         - FailAid\Context\FailureContext
 
   extensions:
@@ -34,7 +34,7 @@ default:
             api_url: http://localhost:9222
             validate_certificate: false
 
-    PaulGibbs\WordpressBehatExtension:
+    WordHat\Extension:
       path: tests/app/www/
       users:
         -


### PR DESCRIPTION
## Description

This changes the PHP namespace of the library to `WordHat`.

## Motivation and context

This removes the association with any given developer (hello, Paul) and allows the project to carry on should the primary maintainer decide not to -- or no longer be able to -- maintain the project further.
