### PR TITLE
Use Friends of Behat mink extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "behat/behat": "~3.1",
     "php": ">=7.2",
     "sensiolabs/behat-page-object-extension": "~2.1",
-    "friends-of-behat/mink-extension": "^2.5",
+    "friends-of-behat/mink-extension": "^2.5"
   },
   "require-dev": {
     "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "behat/behat": "~3.1",
     "php": ">=7.2",
     "sensiolabs/behat-page-object-extension": "~2.1",
-    "behat/mink-extension": "~2.3"
+    "friends-of-behat/mink-extension": "^2.5",
   },
   "require-dev": {
     "behat/mink-goutte-driver": "^1.2",


### PR DESCRIPTION
`behat/mink-extension` is [in bugfix-only mode](https://github.com/Behat/MinkExtension/issues/370#issuecomment-770235890) and `friends-of-behat/mink-extension` seems to be [the maintained fork](https://github.com/FriendsOfBehat/MinkExtension).

Additionally, `sensiolabs/behat-page-object-extension` requires the `friends-of-behat/mink-extension` package, so this package results in installing both copies of the mink extension package.